### PR TITLE
Add utility for plotting individual phonon dispersion curves and a PDF of dispersion curves for all materials in a results directory

### DIFF
--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -323,7 +323,7 @@ def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
             if common_legend:
                 handles, labels = axs[0].get_legend_handles_labels()
                 default_legend_args = dict(
-                    loc="upper center",
+                    loc="lower center",
                     bbox_to_anchor=(0.5, -0.05),
                     fontsize=10,
                     ncol=1

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -1,6 +1,9 @@
 import matplotlib.pyplot as plt
+import re
 import yaml
 import numpy as np
+from itertools import accumulate
+from pathlib import Path
 
 
 # This should probably be moved to io.py
@@ -53,5 +56,125 @@ def _load_band_yaml(band_yaml_path):
             labels[j] = labels[j] + "/" + labels[j+1]
             del labels[j+1]
 
-    return distance, frequencies, labels, seg_nqpoint
+    return distance, frequencies, labels, seg_nqpoint, npath
 
+
+def _get_method_and_material(band_yaml_path):
+    """
+    NOTE: This function may need to be changed to account for different 
+    interatmic potentials. Currently, we are only working with DFT and 
+    the MACE model. 
+
+    Extracts material label ({chemical formula}-{index}) and 
+    method of computation (mlip or dft) for a provided Phonopy band yaml
+    file. This information is used for the label and title in 
+    plot_phonon_dispersion.
+
+    Args:
+        band_yaml_path (Path): Path to the band yaml file output by Phonopy.
+
+    Returns:
+        material_id (str): The material label ({chemical_formula}-{index}). 
+        method (str): Describes the method by which the frequencies in the 
+            band taml file were computed (either mlip or dft). 
+    """
+    parent_folder = Path(band_yaml_path).parent.name
+    # Expect pattern like POSCAR-<material>-<index>-<method>
+    # We want to capture material-index as title and method as label
+
+    pattern = r"POSCAR-([A-Za-z0-9]+-[0-9]+)-(mlip|dft)$"
+    match = re.match(pattern, parent_folder)
+    if match:
+        material_id = match.group(1)  
+        method = match.group(2)   # "mlip" or "dft"
+    else:
+        # fallback values if pattern doesn't match
+        material_id = "MaterialUnknown"
+        method = "MethodUnknown"
+
+    return method, material_id
+
+
+def plot_phonon_dispersion(yaml_files, output_path=None,
+        labels=None, styles=None, **plotting_args):
+    """
+    Plot phonon dispersion curves from a list of phonopy band.yaml files.
+
+    Args:
+        yaml_files (list of Path or str): Paths to band.yaml files.
+        output_path (Path or str): Path to save the output plot (e.g. 
+            'plot.png').
+        labels (list of str): Legend labels for each dataset. If None, 
+            filenames are used.
+        styles (list of dict): Matplotlib style kwargs for each dataset. If 
+            None, defaults are used.
+        **plotting_args: Additional kwargs for figure customization 
+            (figsize, xlabel, ylabel, etc.).
+    """
+    # Define output path directory, make it if it does not exist
+    if output_path is None:
+        output_path = Path.cwd() / "visualizations"
+        output_path.mkdir(parents=True, exist_ok=True)  
+    else:
+        output_path = Path(output_path)
+
+    # If output_path is a directory, define a default filename inside it
+    if output_path.is_dir():
+        output_path = output_path / "bandplot.png"
+
+    # Get method labels if none are passed
+    if labels is None:
+        labels = [_get_method_and_material(f)[0] for f in yaml_files]
+    # Use default if no style dict is passed
+    # Use a unique color for each dataset 
+    if styles is None:
+        styles = [{'color':'C' + str(i)} for i in range(len(yaml_files))]
+
+    # Load first dataset to get xtick info
+    dist, freqs, xtick_labels, seg_nqpoint, npath = (
+            _load_band_yaml(yaml_files[0])
+    )
+
+    # Figure and axis labels
+    figsize = plotting_args.get("figsize", (4, 4))
+    xlabel = plotting_args.get("xlabel", "Wave vector")
+    ylabel = plotting_args.get("ylabel", "Frequency (THz)")
+    title = plotting_args.get("title", 
+            _get_method_and_material(yaml_files[0])[1]) 
+    tick_params = plotting_args.get(
+        "tick_params",
+        dict(
+            axis='both',
+            direction='in',
+            top=True,
+            right=True
+        )
+    )
+
+    plt.figure(figsize=figsize)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+
+    # Set xticks based on segment_nqpoint from first file
+    xticks = list(accumulate(seg_nqpoint))
+    xtick_positions = (
+        [0] 
+        + [dist[xticks[j]] for j in range(npath - 1)] 
+        + [dist[xticks[-1] - 1]]
+    )
+    plt.xticks(xtick_positions, xtick_labels)
+    plt.tick_params(**tick_params)
+
+    # Plot each dataset
+    for yaml_file, label, style in zip(yaml_files, labels, styles):
+        dist, freqs, _, _, _ = _load_band_yaml(yaml_file)
+        num_frequencies = freqs.shape[0]
+        for j in range(num_frequencies):
+            plt.plot(dist, freqs[j], label=label if j == 0 else "", **style)
+
+    plt.title(title)
+    plt.legend()
+    plt.xlim(min(dist), max(dist))
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=300)
+    plt.close()

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -1,0 +1,57 @@
+import matplotlib.pyplot as plt
+import yaml
+import numpy as np
+
+
+# This should probably be moved to io.py
+def _load_band_yaml(band_yaml_path):
+    """
+    Load phonon band structure data from a phonopy band.yaml file.
+
+    Args:
+        band_yaml_path (Path): Path to yaml file containing phonon band 
+            structure data.
+
+    Returns: 
+        distance (np.ndarray): Shape (n_qpoints,), cumulative distance along
+                the path for each q-point.
+        frequencies (np.ndarray): Shape (n_bands, n_qpoints), phonon
+                frequencies in THz.
+        labels (list of str): High-symmetry point labels for x-axis ticks.
+        xtick_positions (list of float): Distances at each high-symmetry
+                point for plotting.
+    """
+    with open(band_yaml_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    phonon = data["phonon"]
+    npath = data["npath"]
+    seg_nqpoint = data["segment_nqpoint"]
+    # Convert to array to flatten, then to list for 
+    # easier deletion / appending
+    labels = np.array(data["labels"]).flatten().tolist()
+
+    distance = []
+    freqs = []
+    xtick_positions = []
+
+    for qpt in phonon:
+        # Get distance and bands
+        dist = qpt["distance"]
+        distance.append(dist)
+        freqs.append([b["frequency"] for b in qpt["band"]])
+
+    # Convert to arrays
+    distance = np.array(distance)
+    frequencies = np.array(freqs).T  # shape (n_bands, n_qpoints)
+
+    # Merge consecutive duplicate labels
+    for j in range(1, npath):
+        if labels[j] == labels[j+1]:
+            del labels[j]
+        else:
+            labels[j] = labels[j] + "/" + labels[j+1]
+            del labels[j+1]
+
+    return distance, frequencies, labels, seg_nqpoint
+

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -21,8 +21,8 @@ def plot_phonon_dispersion(
         figure_kwargs=None, 
         legend_kwargs=None, 
         postprocess=None, 
-        ax=None
-    ):
+        ax=None    
+):
     """
     Plot phonon dispersion curves from a list of phonopy band.yaml files.
 
@@ -257,16 +257,18 @@ def _make_dispersion_page(
     return fig
             
         
-def plot_all_dispersion_curves(results_dir,
-                               output_pdf=None, 
-                               line_styles=None,
-                               max_plots_per_page=40,
-                               common_legend=True,
-                               legend_params=None, 
-                               axis_kwargs=None, 
-                               figure_kwargs=None,
-                               postprocess_subplot=None, 
-                               postprocess_page=None):
+def plot_all_dispersion_curves(
+        results_dir,
+        output_pdf=None, 
+        line_styles=None,
+        max_plots_per_page=40,
+        common_legend=True,
+        legend_params=None, 
+        axis_kwargs=None, 
+        figure_kwargs=None,
+        postprocess_subplot=None, 
+        postprocess_page=None
+):
     """
     Plots phonon dispersion curves for all materials contained in a
     provided results directory. Organizes the figures in a PDF document. 

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -323,8 +323,8 @@ def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
             if common_legend:
                 handles, labels = axs[0].get_legend_handles_labels()
                 default_legend_args = dict(
-                    loc="center left",
-                    bbox_to_anchor=(1.02, 0.5),
+                    loc="upper center",
+                    bbox_to_anchor=(0.5, -0.05),
                     fontsize=10,
                     ncol=1
                 )
@@ -335,5 +335,5 @@ def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
                 # Add legend
                 fig.legend(handles, labels, **legend_args)
 
-            pdf.savefig(fig)
+            pdf.savefig(fig, bbox_inches="tight")
             plt.close(fig)

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -79,9 +79,8 @@ def _get_method_and_material(band_yaml_path):
             band taml file were computed (either mlip or dft). 
     """
     parent_folder = Path(band_yaml_path).parent.name
-    # Expect pattern like POSCAR-<material>-<index>-<method>
+    
     # We want to capture material-index as title and method as label
-
     pattern = r"POSCAR-([A-Za-z0-9]+-[0-9]+)-(mlip|dft)$"
     match = re.match(pattern, parent_folder)
     if match:
@@ -113,14 +112,20 @@ def plot_phonon_dispersion(yaml_files, output_path=None,
     """
     # Define output path directory, make it if it does not exist
     if output_path is None:
-        output_path = Path.cwd() / "visualizations"
-        output_path.mkdir(parents=True, exist_ok=True)  
+        output_path = Path.cwd() / "visualizations" / "bandplot.png"
     else:
         output_path = Path(output_path)
-
-    # If output_path is a directory, define a default filename inside it
-    if output_path.is_dir():
+    
+    # If it looks like a directory or is an existing directory, 
+    # make it and add bandplot.png filename
+    if output_path.suffix == "" or output_path.is_dir():
+        output_path.mkdir(parents=True, exist_ok=True)
         output_path = output_path / "bandplot.png"
+    # If the user specified a filename, make the parent directory if it does
+    # not yet exist 
+    else:
+        # Make sure the parent dir exists
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Get method labels if none are passed
     if labels is None:
@@ -175,6 +180,7 @@ def plot_phonon_dispersion(yaml_files, output_path=None,
     plt.title(title)
     plt.legend()
     plt.xlim(min(dist), max(dist))
+    plt.axhline(0, linestyle='--', color='lightcoral', lw=0.3)
     plt.tight_layout()
     plt.savefig(output_path, dpi=300)
     plt.close()

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -1,124 +1,15 @@
 import matplotlib.pyplot as plt
-import re
-import yaml
 import numpy as np
+from phonomatic.utils.io import (
+    load_band_yaml,
+    get_method_and_material, 
+    create_output_file, 
+    get_grouped_paths, 
+    save_figure, 
+    save_figures_to_pdf
+)
 from itertools import accumulate
 from pathlib import Path
-from matplotlib.backends.backend_pdf import PdfPages
-from collections import defaultdict
-
-
-# This should probably be moved to io.py
-def _load_band_yaml(band_yaml_path):
-    """
-    Load phonon band structure data from a phonopy band.yaml file.
-
-    Args:
-        band_yaml_path (Path): Path to yaml file containing phonon band 
-            structure data.
-
-    Returns: 
-        distance (np.ndarray): Shape (n_qpoints,), cumulative distance along
-            the path for each q-point.
-        frequencies (np.ndarray): Shape (n_bands, n_qpoints), phonon
-            frequencies in THz.
-        labels (list of str): High-symmetry point labels for x-axis ticks.
-        seg_nqpoint (list of int): Number of q-points sampled along each
-            segment of reciprocal space. 
-        npath (int): Number of distinct path segments.  
-    """
-    with open(band_yaml_path, "r") as f:
-        data = yaml.safe_load(f)
-
-    phonon = data["phonon"]
-    npath = data["npath"]
-    seg_nqpoint = data["segment_nqpoint"]
-    # Convert to array to flatten, then to list for 
-    # easier deletion / appending
-    labels = np.array(data["labels"]).flatten().tolist()
-
-    distance = []
-    freqs = []
-    xtick_positions = []
-
-    for qpt in phonon:
-        # Get distance and bands
-        dist = qpt["distance"]
-        distance.append(dist)
-        freqs.append([b["frequency"] for b in qpt["band"]])
-
-    # Convert to arrays
-    distance = np.array(distance)
-    frequencies = np.array(freqs).T  # shape (n_bands, n_qpoints)
-
-    # Merge consecutive duplicate labels
-    for j in range(1, npath):
-        if labels[j] == labels[j+1]:
-            del labels[j]
-        else:
-            labels[j] = labels[j] + "/" + labels[j+1]
-            del labels[j+1]
-
-    return distance, frequencies, labels, seg_nqpoint, npath
-
-
-def _get_method_and_material(band_yaml_path):
-    """
-    NOTE: This function may need to be changed to account for different 
-    interatmic potentials. Currently, we are only working with DFT and 
-    the MACE model. 
-
-    Extracts material label ({chemical formula}-{index}) and 
-    method of computation (mlip or dft) for a provided Phonopy band yaml
-    file. This information is used for the label and title in 
-    plot_phonon_dispersion.
-
-    Args:
-        band_yaml_path (Path): Path to the band yaml file output by Phonopy.
-
-    Returns:
-        material_id (str): The material label ({chemical_formula}-{index}). 
-        method (str): Describes the method by which the frequencies in the 
-            band taml file were computed (either mlip or dft). 
-    """
-    parent_folder = Path(band_yaml_path).parent.name
-    
-    # We want to capture material-index as title and method as label
-    pattern = r"POSCAR-([A-Za-z0-9]+-[0-9]+)-(mlip|dft)$"
-    match = re.match(pattern, parent_folder)
-    if match:
-        material_id = match.group(1)  
-        method = match.group(2)   # "mlip" or "dft"
-    else:
-        # fallback values if pattern doesn't match
-        material_id = "MaterialUnknown"
-        method = "MethodUnknown"
-
-    return method, material_id
-
-
-def _create_output_file(path, file_name):
-    """
-    Creates an output file by checking the validity of a user-specified file
-    path. 
-
-    Args: 
-        path (Path or str): The user-specified path.
-        file_name (str): An output file name (in case the user only specified
-            a directory). 
-    """
-    if path is None:
-        path = Path.cwd() / "visualizations" / file_name
-    else:
-        path = Path(path)
-
-    # Ensure directories exist
-    if path.suffix == "" or path.is_dir():
-        opath.mkdir(parents=True, exist_ok=True)
-        path = path / file_name
-    else:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    return path
     
         
 def plot_phonon_dispersion(yaml_files, output_path=None,
@@ -142,26 +33,26 @@ def plot_phonon_dispersion(yaml_files, output_path=None,
     """
     # Prepare labels and styles
     if labels is None:
-        labels = [_get_method_and_material(f)[0] for f in yaml_files]
+        labels = [get_method_and_material(f)[0] for f in yaml_files]
     if styles is None:
         styles = [{'color': 'C' + str(i)} for i in range(len(yaml_files))]
 
     # Load first dataset for x-ticks and metadata
     dist, freqs, xtick_labels, seg_nqpoint, npath = (
-        _load_band_yaml(yaml_files[0])
+        load_band_yaml(yaml_files[0])
     )
 
     # Decide whether to create our own figure
     own_fig = False
     if ax is None:
         own_fig = True
-        output_path = _create_output_file(output_path, "band_plot.png")
+        output_path = create_output_file(output_path, "band_plot.png")
 
         fig, ax = plt.subplots(figsize=plotting_args.get("figsize", (4, 4)))
 
     xlabel = plotting_args.get("xlabel", "Wave vector")
     ylabel = plotting_args.get("ylabel", "Frequency (THz)")
-    title = plotting_args.get("title", _get_method_and_material(yaml_files[0])[1])
+    title = plotting_args.get("title", get_method_and_material(yaml_files[0])[1])
     tick_params = plotting_args.get(
         "tick_params",
         dict(axis='both', direction='in', top=True, right=True)
@@ -178,7 +69,7 @@ def plot_phonon_dispersion(yaml_files, output_path=None,
 
     # Plot datasets
     for yaml_file, label, style in zip(yaml_files, labels, styles):
-        dist, freqs, _, _, _ = _load_band_yaml(yaml_file)
+        dist, freqs, _, _, _ = load_band_yaml(yaml_file)
         for j in range(freqs.shape[0]):
             ax.plot(dist, freqs[j], label=label if j == 0 else "", **style)
 
@@ -192,46 +83,16 @@ def plot_phonon_dispersion(yaml_files, output_path=None,
     if own_fig:
         ax.legend()
         plt.tight_layout()
-        plt.savefig(output_path, dpi=300)
-        plt.close()
-
-
-def _get_grouped_paths(dirs, file_of_interest):
-    """
-    Helper function to group a list of file directories by material
-    configuration. Used to plot dispersion bands for the same material
-    together in plot_all_dispersion_curves.
-
-    Args:
-        dirs (list of Path): List containing paths to computation results for
-            input POSCAR files ('POSCAR' should be included in path names). 
-        file_of_interest (str): Phonopy output file name to be extracted from 
-            material directories. 
-
-    Returns: 
-        grouped_dirs_list (list of list of Path): Output paths grouped 
-            by material configuration. 
-        **plotting_args: Additional kwargs for figure customization (figsize,
-            xlabel, ylabel, etc.).
-    """
-    grouped_dirs = defaultdict(list)
-    for d in dirs:
-        stem = d.stem
-        match = re.match(r"^POSCAR-([A-Za-z0-9]+-\d+)-.*$", stem)
-        if match:
-            # Material ID is formula + ICSD
-            material_id = match.group(1)
-        else:
-            # Fallback: use the whole stem as its own ID
-            material_id = stem
-        grouped_dirs[material_id].append(d / file_of_interest)
-    grouped_dirs_list = list(grouped_dirs.values())
-    return grouped_dirs_list
+        save_figure(fig, output_path, file_name="band_plot.png", dpi=300)
 
 
 def _get_page_layout(plots_this_page):
     """
     Helper function to determine the arrangment of plots on a single page.
+    
+    NOTE: I am choosing to keep this in the plotting module for now because 
+    it has to do with the visual layout of our plots. It does not read or
+    write data from/to a file. 
 
     Args:
         plots_this_page (int): Number of figures to be placed on the page. 
@@ -240,7 +101,6 @@ def _get_page_layout(plots_this_page):
         n_row (int): Number of rows of figures. 
         n_col (int): Number of columns of figures. 
     """
-
     n_col = int(np.sqrt(plots_this_page))
     n_row = np.ceil(plots_this_page / n_col)
 
@@ -252,6 +112,55 @@ def _get_page_layout(plots_this_page):
         n_col -= 1
         n_row = np.ceil(plots_this_page / n_col)
     return int(n_row), n_col
+
+
+def _make_dispersion_page(batch, styles, common_legend,
+                          legend_params, **plotting_args):
+    """
+    Creates a single page of phonon dispersion plots. 
+
+    Args:
+        batch (list of list of Path): Paths to band.yaml datasets for 
+            plotting.
+        styles (list of dict): Matplotlib style kwargs for each dataset used
+            to make a single plot. 
+        common_legend (Bool): Whether to add a common legend on the page. 
+        legend_params (dict):  Optional keyword arguments passed to 
+            `fig.legend()` if common_legend is True.
+        **plotting_args: Additional kwargs for figure customization (figsize,
+            xlabel, ylabel, etc.).
+
+    Returns:
+        fig (matplotlib.figure.Figure): The page of phonon dispersion curves.
+    """
+    # Define layout for this page
+    n_row, n_col = _get_page_layout(len(batch))
+    fig, axs = plt.subplots(n_row, n_col, 
+                            figsize=(8.5, 11),
+                            constrained_layout=True)
+    # Flatten to 1D array for easier indexing
+    
+    axs = np.atleast_1d(axs).flatten()
+
+    # Plot each phonon dispersion curve in batch
+    for ax, yaml_group in zip(axs, batch):
+        plot_phonon_dispersion(yaml_group, ax=ax, 
+                               styles=styles, **plotting_args)
+
+    # Turn off unused subplots
+    for ax in axs[len(batch):]:
+        ax.axis('off')
+
+    # Add legend
+    if common_legend:
+        handles, labels = axs[0].get_legend_handles_labels()
+        default_args = dict(loc="lower center", bbox_to_anchor=(0.5, -0.05), 
+                            fontsize=10, ncol=1)
+        # Merge user-provided legend parameters with the defaults
+        legend_args = {**default_args, **(legend_params or {})}
+        fig.legend(handles, labels, **legend_args)
+
+    return fig
             
         
 def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
@@ -281,7 +190,7 @@ def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
     results_dir = Path(results_dir)
     
     # Make sure path to output_pdf exists
-    output_pdf = _create_output_file(output_pdf, 'band_plots.pdf')
+    output_pdf = create_output_file(output_pdf, 'band_plots.pdf')
 
     # Get output directories for unique materials
     material_dirs = [d.resolve() for d in results_dir.iterdir() 
@@ -289,51 +198,26 @@ def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
     
     # For materials that share the same configuration (chemical formula
     # and ICSD), plot them together in the same figure 
-    grouped_paths = _get_grouped_paths(material_dirs, 
-                                       file_of_interest='band.yaml')
+    grouped_paths = get_grouped_paths(material_dirs, 
+                                      file_of_interest='band.yaml')
     n_plots = len(grouped_paths)
     if n_plots == 0:
         print("No materials found in directory.")
         return
-    n_pages = np.ceil(n_plots / max_plots_per_page)
+    
     # Create batches from path lists - we can only plot max_plots_per_page 
     # per page
-    batched_paths = [grouped_paths[i:max_plots_per_page] 
-                     for i in range(0, n_plots, max_plots_per_page)]
-    with PdfPages(output_pdf) as pdf:
-        for batch in batched_paths:
-            # For now, always plot rectangular layout
-            # TO-DO: Allow user to customize this
-            n_row, n_col = _get_page_layout(len(batch))
-            fig, axs = plt.subplots(n_row, n_col,
-                                    figsize=(8.5, 11),
-                                    constrained_layout=True)
-            # Flatten to 1D array for easier indexing
-            axs = np.atleast_1d(axs).flatten()  
+    batched_paths = [
+        grouped_paths[i:i+max_plots_per_page] 
+        for i in range(0, len(grouped_paths), max_plots_per_page)
+    ]
 
-            # Plot each material into its subplot
-            for ax, yaml_group in zip(axs, batch):
-                plot_phonon_dispersion(yaml_group, ax=ax, 
-                                       styles=styles, **plotting_args)
+    # Create each page
+    figures = [
+        _make_dispersion_page(batch, styles, common_legend, 
+                              legend_params, **plotting_args)
+        for batch in batched_paths
+    ]
 
-            # Turn off unused subplots
-            for ax in axs[len(batch):]:
-                ax.axis('off')
-
-            if common_legend:
-                handles, labels = axs[0].get_legend_handles_labels()
-                default_legend_args = dict(
-                    loc="lower center",
-                    bbox_to_anchor=(0.5, -0.05),
-                    fontsize=10,
-                    ncol=1
-                )
-    
-                # Merge user-provided args
-                legend_args = {**default_legend_args, **(legend_params or {})}
-                
-                # Add legend
-                fig.legend(handles, labels, **legend_args)
-
-            pdf.savefig(fig, bbox_inches="tight")
-            plt.close(fig)
+    # Combine and save to pdf
+    save_figures_to_pdf(figures, output_pdf, file_name='band_plots.pdf')

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -142,25 +142,34 @@ def _get_page_layout(plots_this_page):
     return int(n_row), n_col
 
 
-def _make_dispersion_page(batch, styles, common_legend,
-                          legend_params, **plotting_args):
+def _make_dispersion_page(batch, 
+                          line_styles, 
+                          common_legend,
+                          legend_params, 
+                          axis_kwargs,
+                          figure_kwargs,
+                          postprocess):
     """
-    Creates a single page of phonon dispersion plots. 
-
+    Creates a single page of phonon dispersion plots.
+    
     Args:
         batch (list of list of Path): Paths to band.yaml datasets for 
             plotting.
-        styles (list of dict): Matplotlib style kwargs for each dataset used
-            to make a single plot. 
-        common_legend (Bool): Whether to add a common legend on the page. 
-        legend_params (dict):  Optional keyword arguments passed to 
-            `fig.legend()` if common_legend is True.
-        **plotting_args: Additional kwargs for figure customization (figsize,
-            xlabel, ylabel, etc.).
-
+        line_styles (list of dict): Matplotlib style kwargs for the datasets 
+            used to make a single plot.
+        common_legend (bool): Whether to add a common legend on the page.
+        legend_params (dict): Optional keyword arguments passed to 
+            `fig.legend()`if common_legend is True.
+        axis_kwargs (dict): Axis customization options for each plot 
+            (xlabel, ylabel, tick_params, title, etc.).
+        figure_kwargs (dict): Figure customization options (e.g., figsize).
+        postprocess (callable): Function taking an `ax` for additional 
+            customization of each subplot.
+    
     Returns:
         fig (matplotlib.figure.Figure): The page of phonon dispersion curves.
     """
+
     # Define layout for this page
     n_row, n_col = _get_page_layout(len(batch))
     fig, axs = plt.subplots(n_row, n_col, 
@@ -172,8 +181,14 @@ def _make_dispersion_page(batch, styles, common_legend,
 
     # Plot each phonon dispersion curve in batch
     for ax, yaml_group in zip(axs, batch):
-        plot_phonon_dispersion(yaml_group, ax=ax, 
-                               styles=styles, **plotting_args)
+        plot_phonon_dispersion(
+            yaml_group,
+            ax=ax,
+            line_styles=line_styles,
+            axis_kwargs=axis_kwargs,
+            figure_kwargs=figure_kwargs,
+            postprocess=postprocess,
+        )
 
     # Turn off unused subplots
     for ax in axs[len(batch):]:
@@ -191,29 +206,35 @@ def _make_dispersion_page(batch, styles, common_legend,
     return fig
             
         
-def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
+def plot_all_dispersion_curves(results_dir,
+                               output_pdf=None, 
+                               line_styles=None,
                                max_plots_per_page=40,
                                common_legend=True,
                                legend_params=None, 
-                               **plotting_args):
+                               axis_kwargs=None, 
+                               figure_kwargs=None,
+                               postprocess=None):
     """
     Plots phonon dispersion curves for all materials contained in a
     provided results directory. Organizes the figures in a PDF document. 
 
-    Args: 
-        results_dir (Path): Directories containing outputs of Phonopy 
+    Args:
+        results_dir (Path): Directory containing outputs of Phonopy 
             computations.
-        output_pdf (Path): Path to the desired output PDF file. 
-        styles (list of dict): Matplotlib style kwargs for the datasets used
-            to make a single plot. 
-        max_plots_per_page (int): The maximum number of plots to be placed on
-            a single page of the output PDF document.
-        common_legend (Bool): Whether to add a common legend on each page of 
-            the PDF output file. 
-        legend_params (dict):  Optional keyword arguments passed to 
-            `fig.legend()` if common_legend is True.
-        **plotting_args: Additional kwargs for figure customization (figsize,
-            xlabel, ylabel, etc.).
+        output_pdf (Path): Path to the desired output PDF file.
+        line_styles (list of dict): Matplotlib style kwargs for the datasets
+            used to make a single plot.
+        max_plots_per_page (int): Maximum number of plots to place on a 
+            single page of the PDF.
+        common_legend (bool): Whether to add a common legend on each page.
+        legend_params (dict): Optional keyword arguments passed to `fig.legend()`
+            if common_legend is True.
+        axis_kwargs (dict): Axis customization options for each plot (xlabel, ylabel,
+            tick_params, title, etc.).
+        figure_kwargs (dict): Figure customization options.
+        postprocess (callable): Function taking an `ax` for additional customization
+            of each subplot.
     """
     results_dir = Path(results_dir)
     
@@ -242,8 +263,13 @@ def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
 
     # Create each page
     figures = [
-        _make_dispersion_page(batch, styles, common_legend, 
-                              legend_params, **plotting_args)
+        _make_dispersion_page(batch,
+                              line_styles=line_styles,
+                              common_legend=common_legend,
+                              legend_params=legend_params,
+                              axis_kwargs=axis_kwargs,
+                              figure_kwargs=figure_kwargs,
+                              postprocess=postprocess)
         for batch in batched_paths
     ]
 

--- a/src/phonomatic/analysis/plotting.py
+++ b/src/phonomatic/analysis/plotting.py
@@ -4,6 +4,8 @@ import yaml
 import numpy as np
 from itertools import accumulate
 from pathlib import Path
+from matplotlib.backends.backend_pdf import PdfPages
+from collections import defaultdict
 
 
 # This should probably be moved to io.py
@@ -17,12 +19,13 @@ def _load_band_yaml(band_yaml_path):
 
     Returns: 
         distance (np.ndarray): Shape (n_qpoints,), cumulative distance along
-                the path for each q-point.
+            the path for each q-point.
         frequencies (np.ndarray): Shape (n_bands, n_qpoints), phonon
-                frequencies in THz.
+            frequencies in THz.
         labels (list of str): High-symmetry point labels for x-axis ticks.
-        xtick_positions (list of float): Distances at each high-symmetry
-                point for plotting.
+        seg_nqpoint (list of int): Number of q-points sampled along each
+            segment of reciprocal space. 
+        npath (int): Number of distinct path segments.  
     """
     with open(band_yaml_path, "r") as f:
         data = yaml.safe_load(f)
@@ -94,93 +97,243 @@ def _get_method_and_material(band_yaml_path):
     return method, material_id
 
 
+def _create_output_file(path, file_name):
+    """
+    Creates an output file by checking the validity of a user-specified file
+    path. 
+
+    Args: 
+        path (Path or str): The user-specified path.
+        file_name (str): An output file name (in case the user only specified
+            a directory). 
+    """
+    if path is None:
+        path = Path.cwd() / "visualizations" / file_name
+    else:
+        path = Path(path)
+
+    # Ensure directories exist
+    if path.suffix == "" or path.is_dir():
+        opath.mkdir(parents=True, exist_ok=True)
+        path = path / file_name
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+    
+        
 def plot_phonon_dispersion(yaml_files, output_path=None,
-        labels=None, styles=None, **plotting_args):
+        labels=None, styles=None, ax=None, **plotting_args):
     """
     Plot phonon dispersion curves from a list of phonopy band.yaml files.
 
+    If `ax` is provided, plots into that axis and does NOT save a file.
+    If `ax` is None, creates a new figure and saves to `output_path` if given.
+
     Args:
         yaml_files (list of Path or str): Paths to band.yaml files.
-        output_path (Path or str): Path to save the output plot (e.g. 
-            'plot.png').
+        output_path (Path or str): Path to save the output plot (default 
+            bandplot.png).
         labels (list of str): Legend labels for each dataset. If None, 
             filenames are used.
-        styles (list of dict): Matplotlib style kwargs for each dataset. If 
-            None, defaults are used.
-        **plotting_args: Additional kwargs for figure customization 
-            (figsize, xlabel, ylabel, etc.).
+        styles (list of dict): Matplotlib style kwargs for each dataset.
+        ax (matplotlib.axes.Axes): Optional axis to plot into.
+        **plotting_args: Additional kwargs for figure customization (figsize,
+            xlabel, ylabel, etc.).
     """
-    # Define output path directory, make it if it does not exist
-    if output_path is None:
-        output_path = Path.cwd() / "visualizations" / "bandplot.png"
-    else:
-        output_path = Path(output_path)
-    
-    # If it looks like a directory or is an existing directory, 
-    # make it and add bandplot.png filename
-    if output_path.suffix == "" or output_path.is_dir():
-        output_path.mkdir(parents=True, exist_ok=True)
-        output_path = output_path / "bandplot.png"
-    # If the user specified a filename, make the parent directory if it does
-    # not yet exist 
-    else:
-        # Make sure the parent dir exists
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Get method labels if none are passed
+    # Prepare labels and styles
     if labels is None:
         labels = [_get_method_and_material(f)[0] for f in yaml_files]
-    # Use default if no style dict is passed
-    # Use a unique color for each dataset 
     if styles is None:
-        styles = [{'color':'C' + str(i)} for i in range(len(yaml_files))]
+        styles = [{'color': 'C' + str(i)} for i in range(len(yaml_files))]
 
-    # Load first dataset to get xtick info
+    # Load first dataset for x-ticks and metadata
     dist, freqs, xtick_labels, seg_nqpoint, npath = (
-            _load_band_yaml(yaml_files[0])
+        _load_band_yaml(yaml_files[0])
     )
 
-    # Figure and axis labels
-    figsize = plotting_args.get("figsize", (4, 4))
+    # Decide whether to create our own figure
+    own_fig = False
+    if ax is None:
+        own_fig = True
+        output_path = _create_output_file(output_path, "band_plot.png")
+
+        fig, ax = plt.subplots(figsize=plotting_args.get("figsize", (4, 4)))
+
     xlabel = plotting_args.get("xlabel", "Wave vector")
     ylabel = plotting_args.get("ylabel", "Frequency (THz)")
-    title = plotting_args.get("title", 
-            _get_method_and_material(yaml_files[0])[1]) 
+    title = plotting_args.get("title", _get_method_and_material(yaml_files[0])[1])
     tick_params = plotting_args.get(
         "tick_params",
-        dict(
-            axis='both',
-            direction='in',
-            top=True,
-            right=True
-        )
+        dict(axis='both', direction='in', top=True, right=True)
     )
 
-    plt.figure(figsize=figsize)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
-
-    # Set xticks based on segment_nqpoint from first file
+    # Set x-ticks
     xticks = list(accumulate(seg_nqpoint))
-    xtick_positions = (
-        [0] 
-        + [dist[xticks[j]] for j in range(npath - 1)] 
-        + [dist[xticks[-1] - 1]]
-    )
-    plt.xticks(xtick_positions, xtick_labels)
-    plt.tick_params(**tick_params)
+    xtick_positions = ([0] 
+                       + [dist[xticks[j]] for j in range(npath - 1)] 
+                       + [dist[xticks[-1] - 1]])
+    ax.set_xticks(xtick_positions)
+    ax.set_xticklabels(xtick_labels)
+    ax.tick_params(**tick_params)
 
-    # Plot each dataset
+    # Plot datasets
     for yaml_file, label, style in zip(yaml_files, labels, styles):
         dist, freqs, _, _, _ = _load_band_yaml(yaml_file)
-        num_frequencies = freqs.shape[0]
-        for j in range(num_frequencies):
-            plt.plot(dist, freqs[j], label=label if j == 0 else "", **style)
+        for j in range(freqs.shape[0]):
+            ax.plot(dist, freqs[j], label=label if j == 0 else "", **style)
 
-    plt.title(title)
-    plt.legend()
-    plt.xlim(min(dist), max(dist))
-    plt.axhline(0, linestyle='--', color='lightcoral', lw=0.3)
-    plt.tight_layout()
-    plt.savefig(output_path, dpi=300)
-    plt.close()
+    ax.set_title(title)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_xlim(min(dist), max(dist))
+    ax.axhline(0, linestyle='--', color='lightcoral', lw=0.3)
+
+    # Save as a single file if we are generating one figure in isolation
+    if own_fig:
+        ax.legend()
+        plt.tight_layout()
+        plt.savefig(output_path, dpi=300)
+        plt.close()
+
+
+def _get_grouped_paths(dirs, file_of_interest):
+    """
+    Helper function to group a list of file directories by material
+    configuration. Used to plot dispersion bands for the same material
+    together in plot_all_dispersion_curves.
+
+    Args:
+        dirs (list of Path): List containing paths to computation results for
+            input POSCAR files ('POSCAR' should be included in path names). 
+        file_of_interest (str): Phonopy output file name to be extracted from 
+            material directories. 
+
+    Returns: 
+        grouped_dirs_list (list of list of Path): Output paths grouped 
+            by material configuration. 
+        **plotting_args: Additional kwargs for figure customization (figsize,
+            xlabel, ylabel, etc.).
+    """
+    grouped_dirs = defaultdict(list)
+    for d in dirs:
+        stem = d.stem
+        match = re.match(r"^POSCAR-([A-Za-z0-9]+-\d+)-.*$", stem)
+        if match:
+            # Material ID is formula + ICSD
+            material_id = match.group(1)
+        else:
+            # Fallback: use the whole stem as its own ID
+            material_id = stem
+        grouped_dirs[material_id].append(d / file_of_interest)
+    grouped_dirs_list = list(grouped_dirs.values())
+    return grouped_dirs_list
+
+
+def _get_page_layout(plots_this_page):
+    """
+    Helper function to determine the arrangment of plots on a single page.
+
+    Args:
+        plots_this_page (int): Number of figures to be placed on the page. 
+    
+    Returns:
+        n_row (int): Number of rows of figures. 
+        n_col (int): Number of columns of figures. 
+    """
+
+    n_col = int(np.sqrt(plots_this_page))
+    n_row = np.ceil(plots_this_page / n_col)
+
+    # Since we will be placing figures into a standard, portrait-oriented 
+    # document, we want the number of rows to be larger than the number
+    # of columns to create a rectangular layout
+    if n_col == n_row and n_col != 1:  # Single plot -> 1 row, 
+                                       # 1 col is only option
+        n_col -= 1
+        n_row = np.ceil(plots_this_page / n_col)
+    return int(n_row), n_col
+            
+        
+def plot_all_dispersion_curves(results_dir, output_pdf=None, styles=None,
+                               max_plots_per_page=40,
+                               common_legend=True,
+                               legend_params=None, 
+                               **plotting_args):
+    """
+    Plots phonon dispersion curves for all materials contained in a
+    provided results directory. Organizes the figures in a PDF document. 
+
+    Args: 
+        results_dir (Path): Directories containing outputs of Phonopy 
+            computations.
+        output_pdf (Path): Path to the desired output PDF file. 
+        styles (list of dict): Matplotlib style kwargs for the datasets used
+            to make a single plot. 
+        max_plots_per_page (int): The maximum number of plots to be placed on
+            a single page of the output PDF document.
+        common_legend (Bool): Whether to add a common legend on each page of 
+            the PDF output file. 
+        legend_params (dict):  Optional keyword arguments passed to 
+            `fig.legend()` if common_legend is True.
+        **plotting_args: Additional kwargs for figure customization (figsize,
+            xlabel, ylabel, etc.).
+    """
+    results_dir = Path(results_dir)
+    
+    # Make sure path to output_pdf exists
+    output_pdf = _create_output_file(output_pdf, 'band_plots.pdf')
+
+    # Get output directories for unique materials
+    material_dirs = [d.resolve() for d in results_dir.iterdir() 
+                     if 'POSCAR' in str(d)]
+    
+    # For materials that share the same configuration (chemical formula
+    # and ICSD), plot them together in the same figure 
+    grouped_paths = _get_grouped_paths(material_dirs, 
+                                       file_of_interest='band.yaml')
+    n_plots = len(grouped_paths)
+    if n_plots == 0:
+        print("No materials found in directory.")
+        return
+    n_pages = np.ceil(n_plots / max_plots_per_page)
+    # Create batches from path lists - we can only plot max_plots_per_page 
+    # per page
+    batched_paths = [grouped_paths[i:max_plots_per_page] 
+                     for i in range(0, n_plots, max_plots_per_page)]
+    with PdfPages(output_pdf) as pdf:
+        for batch in batched_paths:
+            # For now, always plot rectangular layout
+            # TO-DO: Allow user to customize this
+            n_row, n_col = _get_page_layout(len(batch))
+            fig, axs = plt.subplots(n_row, n_col,
+                                    figsize=(8.5, 11),
+                                    constrained_layout=True)
+            # Flatten to 1D array for easier indexing
+            axs = np.atleast_1d(axs).flatten()  
+
+            # Plot each material into its subplot
+            for ax, yaml_group in zip(axs, batch):
+                plot_phonon_dispersion(yaml_group, ax=ax, 
+                                       styles=styles, **plotting_args)
+
+            # Turn off unused subplots
+            for ax in axs[len(batch):]:
+                ax.axis('off')
+
+            if common_legend:
+                handles, labels = axs[0].get_legend_handles_labels()
+                default_legend_args = dict(
+                    loc="center left",
+                    bbox_to_anchor=(1.02, 0.5),
+                    fontsize=10,
+                    ncol=1
+                )
+    
+                # Merge user-provided args
+                legend_args = {**default_legend_args, **(legend_params or {})}
+                
+                # Add legend
+                fig.legend(handles, labels, **legend_args)
+
+            pdf.savefig(fig)
+            plt.close(fig)

--- a/src/phonomatic/utils/io.py
+++ b/src/phonomatic/utils/io.py
@@ -1,5 +1,11 @@
+import yaml
+import re
+import numpy as np
+import matplotlib.pyplot as plt
 from pymatgen.core import Structure
 from pathlib import Path
+from collections import defaultdict
+from matplotlib.backends.backend_pdf import PdfPages
 
 
 def load_structure(structure_path):
@@ -16,6 +22,7 @@ def load_structure(structure_path):
     return Structure.from_file(structure_path)
 
 
+#================== Functions for Writing Phonopy Outputs ==================#
 def write_force_constants(phonon, output_path):
     """
     Saves the force constants to a file.
@@ -70,7 +77,8 @@ def write_thermal_properties(phonon, output_path, mesh):
     """
     try:
         phonon.run_mesh(mesh)
-        phonon.run_thermal_properties(t_step=100, t_max=2000, t_min=100, cutoff_frequency=0.1)
+        phonon.run_thermal_properties(t_step=100, t_max=2000, t_min=100, 
+                                      cutoff_frequency=0.1)
         phonon.write_yaml_thermal_properties(filename=output_path)
     except Exception as e:
         print(f"[WARNING] Could not write thermal properties YAML: {e}")
@@ -103,7 +111,8 @@ def save_phonopy_results(phonon, output_prefix, mesh):
         mesh (int): Mesh density for thermal and DOS calculations.
     """
     output_paths = []
-    for file_to_create in ['FORCE_CONSTANTS', 'band.yaml', 'thermal.yaml', 'total_dos.dat']:
+    for file_to_create in ['FORCE_CONSTANTS', 'band.yaml', 
+                           'thermal.yaml', 'total_dos.dat']:
         path = Path(output_prefix / file_to_create)
         path.parent.mkdir(parents=True, exist_ok=True)
         output_paths.append(path)
@@ -112,3 +121,181 @@ def save_phonopy_results(phonon, output_prefix, mesh):
     write_thermal_properties(phonon, output_paths[2], mesh)
     write_total_dos(phonon, output_paths[3])
 
+
+#====================== Helper Functions for Plotting ======================#
+def load_band_yaml(band_yaml_path):
+    """
+    Load phonon band structure data from a phonopy band.yaml file.
+
+    Args:
+        band_yaml_path (Path): Path to yaml file containing phonon band 
+            structure data.
+
+    Returns: 
+        distance (np.ndarray): Shape (n_qpoints,), cumulative distance along
+            the path for each q-point.
+        frequencies (np.ndarray): Shape (n_bands, n_qpoints), phonon
+            frequencies in THz.
+        labels (list of str): High-symmetry point labels for x-axis ticks.
+        seg_nqpoint (list of int): Number of q-points sampled along each
+            segment of reciprocal space. 
+        npath (int): Number of distinct path segments.  
+    """
+    with open(band_yaml_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    phonon = data["phonon"]
+    npath = data["npath"]
+    seg_nqpoint = data["segment_nqpoint"]
+    # Convert to array to flatten, then to list for 
+    # easier deletion / appending
+    labels = np.array(data["labels"]).flatten().tolist()
+
+    distance = []
+    freqs = []
+    xtick_positions = []
+
+    for qpt in phonon:
+        # Get distance and bands
+        dist = qpt["distance"]
+        distance.append(dist)
+        freqs.append([b["frequency"] for b in qpt["band"]])
+
+    # Convert to arrays
+    distance = np.array(distance)
+    frequencies = np.array(freqs).T  # shape (n_bands, n_qpoints)
+
+    # Merge consecutive duplicate labels
+    for j in range(1, npath):
+        if labels[j] == labels[j+1]:
+            del labels[j]
+        else:
+            labels[j] = labels[j] + "/" + labels[j+1]
+            del labels[j+1]
+
+    return distance, frequencies, labels, seg_nqpoint, npath
+
+
+def get_method_and_material(band_yaml_path):
+    """
+    NOTE: This function may need to be changed to account for different 
+    interatmic potentials. Currently, we are only working with DFT and 
+    the MACE model. 
+
+    Extracts material label ({chemical formula}-{index}) and 
+    method of computation (mlip or dft) for a provided Phonopy band yaml
+    file. This information is used for the label and title in 
+    plot_phonon_dispersion.
+
+    Args:
+        band_yaml_path (Path): Path to the band yaml file output by Phonopy.
+
+    Returns:
+        material_id (str): The material label ({chemical_formula}-{index}). 
+        method (str): Describes the method by which the frequencies in the 
+            band taml file were computed (either mlip or dft). 
+    """
+    parent_folder = Path(band_yaml_path).parent.name
+    
+    # We want to capture material-index as title and method as label
+    pattern = r"POSCAR-([A-Za-z0-9]+-[0-9]+)-(mlip|dft)$"
+    match = re.match(pattern, parent_folder)
+    if match:
+        material_id = match.group(1)  
+        method = match.group(2)   # "mlip" or "dft"
+    else:
+        # fallback values if pattern doesn't match
+        material_id = "MaterialUnknown"
+        method = "MethodUnknown"
+
+    return method, material_id
+
+
+def create_output_file(path, file_name):
+    """
+    Creates an output file by checking the validity of a user-specified file
+    path. 
+
+    Args: 
+        path (Path or str): The user-specified path.
+        file_name (str): An output file name (in case the user only specified
+            a directory). 
+    """
+    if path is None:
+        path = Path.cwd() / "visualizations" / file_name
+    else:
+        path = Path(path)
+
+    # Ensure directories exist
+    if path.suffix == "" or path.is_dir():
+        path.mkdir(parents=True, exist_ok=True)
+        path = path / file_name
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def save_figure(figure, output_path, file_name, dpi=300):
+    """
+    Save a Matplotlib figure to a PNG file.
+
+    Args:
+        fig (matplotlib.figure.Figure): The figure to save.
+         output_path (Path): Figure output path. 
+        file_name (str): A filename used to create a complete save path if 
+            the user only specifies an output directory. 
+    """
+    output_path = create_output_file(output_path, file_name)
+    figure.savefig(output_path, dpi=dpi, bbox_inches="tight")
+    plt.close(figure)
+
+
+def get_grouped_paths(dirs, file_of_interest):
+    """
+    Helper function to group a list of file directories by material
+    configuration. Used to plot dispersion bands for the same material
+    together in plot_all_dispersion_curves.
+
+    Args:
+        dirs (list of Path): List containing paths to computation results for
+            input POSCAR files ('POSCAR' should be included in path names). 
+        file_of_interest (str): Phonopy output file name to be extracted from 
+            material directories. 
+
+    Returns: 
+        grouped_dirs_list (list of list of Path): Output paths grouped 
+            by material configuration. 
+        **plotting_args: Additional kwargs for figure customization (figsize,
+            xlabel, ylabel, etc.).
+    """
+    grouped_dirs = defaultdict(list)
+    for d in dirs:
+        stem = d.stem
+        match = re.match(r"^POSCAR-([A-Za-z0-9]+-\d+)-.*$", stem)
+        if match:
+            # Material ID is formula + ICSD
+            material_id = match.group(1)
+        else:
+            # Fallback: use the whole stem as its own ID
+            material_id = stem
+        grouped_dirs[material_id].append(d / file_of_interest)
+    grouped_dirs_list = list(grouped_dirs.values())
+    return grouped_dirs_list
+
+
+def save_figures_to_pdf(figures, output_path, file_name):
+    """
+    Saves a list of figures to an output PDF file. 
+
+    Args:
+        figures (list of matplotlib.figure.Figure): Figures to be saved to 
+            the PDF.
+        output_path (Path): PDF output path. 
+        file_name (str): A filename used to create a complete save path if 
+            the user only specifies an output directory. 
+    """
+    output_path = create_output_file(output_path, file_name)
+    with PdfPages(output_path) as pdf:
+        for fig in figures:
+            pdf.savefig(fig, bbox_inches="tight")
+            plt.close(fig)


### PR DESCRIPTION
These changes allow the user to analyze the results of Phonopy computation output by plotting phonon dispersion curves. There are two main functions they can use to do so: 

`plot_phonon_dispersion` takes a list of `band.yaml` files as its primary input. Each file should contain phonon band data extracted from a particular material, with unique files corresponding to different interatomic potentials. The stems of the `band.yaml` files are assumed to have the format `<results directory>/POSCAR-<chemical formula>-<ICSD number>-<method suffix (mlip or dft)>` for automatic extraction of plot titles and legend labels. Users can supply their own titles and labels if this assumption is violated. In fact, this code was written to give users as much stylistic flexibility as possible, with the option to post-process figures to make customization not possible with hard-coded function parameters. An example call may look like: 
```python
plot_phonon_dispersion(
    yaml_files,
    output_path="Si_phonon_dispersion.png",
    labels=["DFT", "MACE"],
    line_styles=[
        {"color": "black", "linestyle": "-"},   # solid line for DFT
        {"color": "orange", "linestyle": "--"}, # dashed line for model
    ],
    axis_kwargs={
        "xlabel": "Wave vector",
        "ylabel": "Frequency (THz)",
        "title": "Silicon Phonon Dispersion (DFT vs Model)",
    },
    legend_kwargs={"loc": "upper right"},
)
```
`plot_all_dispersion_curves` plots all dispersion curves and organizes them into a PDF for all materials in a provided output directory. It allows for customization of individual subplots and entire pages. An example call looks like: 
```python 
plot_all_dispersion_curves(
    "phonopy_results/",
    output_pdf="all_dispersion_curves.pdf",
    line_styles=[{"color": "black", "linestyle": "-"}],  # uniform style
    axis_kwargs=[
        {"title": "Silicon"},
        {"title": "Germanium"},
    ],  # per-subplot titles
    postprocess_subplot=[lambda ax: ax.axhspan(-5, 0, color="red", alpha=0.1), None],
    max_plots_per_page=12,
    common_legend=True,
    legend_params={"loc": "upper center", "ncol": 2, "fontsize": 8},
    figure_kwargs={"figsize": (8.5, 11)},
)
```